### PR TITLE
Fix checksums not being optional

### DIFF
--- a/src/main/app/queue-listeners.xml
+++ b/src/main/app/queue-listeners.xml
@@ -277,10 +277,10 @@ where pid = #[flowVars.pid]]]></db:parameterized-query>
 	'metadata': flowVars.request.metadata,
 	'agents': flowVars.request.agents,
 	'fileUse': flowVars.request.fileUse,
-	'checksums': flowVars.request.checksums mapObject using (filename = fileFunctions.destinationName($$, fileFunctions.getType($$), fileFunctions.getExtension($$), flowVars.pid))
+	('checksums': flowVars.request.checksums mapObject using (filename = fileFunctions.destinationName($$, fileFunctions.getType($$), fileFunctions.getExtension($$), flowVars.pid))
 	{
 		'$filename': $
-	},
+	}) when flowVars.request.checksums?,
 	'excludes': [ '.complex', '.nfs']
 }]]>
                     </dw:set-payload>


### PR DESCRIPTION
When there are no checksums provided, the transformation still tried to map them and caused errors.